### PR TITLE
Fix auth onboarding flow

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,58 @@
-import { type NextRequest } from 'next/server'
+import { NextResponse, type NextRequest } from 'next/server'
 import { updateSession } from './utils/supabase/middleware'
+import { createClient } from '@supabase/supabase-js'
+import { db } from './src/db'
+import { users, customers } from './src/db/schema'
+import { eq } from 'drizzle-orm'
 
 export async function middleware(request: NextRequest) {
-  return await updateSession(request)
+  // keep the Supabase session in sync
+  const response = await updateSession(request)
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      global: {
+        headers: { Authorization: request.headers.get('Authorization')! },
+      },
+    }
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  const { pathname } = request.nextUrl
+
+  // unauthenticated users
+  if (!user) {
+    const allowed = ['/', '/map', '/sign-in', '/sign-up', '/callback', '/error', '/confirm-email']
+    if (!allowed.includes(pathname)) {
+      return NextResponse.redirect(new URL('/sign-in', request.url))
+    }
+    return response
+  }
+
+  // logged in users - verify onboarding
+  const userRow = await db.query.users.findFirst({
+    where: eq(users.id, user.id),
+    columns: { id: true },
+  })
+  const customerRow = await db.query.customers.findFirst({
+    where: eq(customers.userId, user.id),
+    columns: { id: true },
+  })
+  const onboarded = !!userRow && !!customerRow
+
+  if (!onboarded && pathname !== '/') {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+
+  if (onboarded && ['/sign-in', '/sign-up'].includes(pathname)) {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+
+  return response
 }
 
 export const config = {
@@ -14,6 +64,6 @@ export const config = {
      * - favicon.ico (favicon file)
      * Feel free to modify this pattern to include more paths.
      */
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|api|auth|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 }

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { db } from '@/src/db';
-import { customers } from '@/src/db/schema';
+import { users, customers } from '@/src/db/schema';
 import { eq } from 'drizzle-orm';
 
 export async function GET(request: NextRequest) {
@@ -13,8 +13,17 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const onboarded = (await db.query.customers.findFirst({ where: eq(customers.userId, user.id) })) !== undefined;
-    return NextResponse.json({ onboarded });
+    const userRow = await db.query.users.findFirst({
+      where: eq(users.id, user.id),
+      columns: { id: true }
+    })
+    const customerRow = await db.query.customers.findFirst({
+      where: eq(customers.userId, user.id),
+      columns: { id: true }
+    })
+
+    const onboarded = !!userRow && !!customerRow
+    return NextResponse.json({ onboarded })
   } catch (err) {
     console.error('Onboarding status error:', err);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });


### PR DESCRIPTION
## Summary
- ensure middleware checks onboarding and routes correctly
- verify user and customer rows via onboarding status API

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684769ad3bbc832b8110738d7b2d3066