### PR TITLE
Fix sign-in redirect for non onboarded users

### DIFF
--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -20,7 +20,6 @@ export default function SignIn() {
       const { data: { user } } = await supabase.auth.getUser();
       
       if (user) {
-        // Check onboarding status
         try {
           const res = await fetch('/api/onboarding/status');
           if (res.ok) {
@@ -29,6 +28,9 @@ export default function SignIn() {
               router.push('/messages');
               return;
             }
+            // Logged in but not onboarded -> go to landing for onboarding flow
+            router.push('/');
+            return;
           }
         } catch (error) {
           console.error('Error checking onboarding status:', error);


### PR DESCRIPTION
## Summary
- ensure users who are logged in but not onboarded are sent to the landing page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684772486aa4832b86dad55b3b404709